### PR TITLE
Fix compilation issue with new Log::Any

### DIFF
--- a/lib/MarpaX/Languages/C/AST/Impl/Logger.pm
+++ b/lib/MarpaX/Languages/C/AST/Impl/Logger.pm
@@ -34,7 +34,7 @@ sub TIEHANDLE {
 
   my $self = {
               level => exists($options{level}) ? ($options{level} || 'trace') : 'trace',
-              category => exists($options{category}) ? ($options{category} || '') : '',
+              category => $options{category}, # possible undef is OK
              };
 
   $self->{logger} = Log::Any->get_logger(category => $self->{category});


### PR DESCRIPTION
Hi!

With the patch I fix the following issue:

```
/tmp/1/MarpaX-Languages-C-AST/ prove -l --norc -r t/asm-opaque.t 
t/asm-opaque.t .. 1/2 
#   Failed test 'use MarpaX::Languages::C::AST;'
#   at t/asm-opaque.t line 8.
#     Tried to use 'MarpaX::Languages::C::AST'.
#     Error:  Log::Any::Proxy requires an 'category' parameter at /home/basiliscos/perl5/perlbrew/perls/perl-5.20.1/lib/site_perl/5.20.1/Log/Any.pm line 84.
# BEGIN failed--compilation aborted at /tmp/1/MarpaX-Languages-C-AST/lib/MarpaX/Languages/C/AST/Impl.pm line 36, <DATA> line 1.
# Compilation failed in require at /tmp/1/MarpaX-Languages-C-AST/lib/MarpaX/Languages/C/AST.pm line 12, <DATA> line 1.
# BEGIN failed--compilation aborted at /tmp/1/MarpaX-Languages-C-AST/lib/MarpaX/Languages/C/AST.pm line 12, <DATA> line 1.
# Compilation failed in require at t/asm-opaque.t line 8, <DATA> line 1.
# BEGIN failed--compilation aborted at t/asm-opaque.t line 8, <DATA> line 1.
Bailout called.  Further testing stopped:  
Can't locate object method "new" via package "MarpaX::Languages::C::AST" at
	t/asm-opaque.t line 13, <DATA> line 1 (#1)
    (F) You called a method correctly, and it correctly indicated a package
    functioning as a class, but that package doesn't define that particular
    method, nor does any of its base classes.  See perlobj.
    
Uncaught exception from user code:
	Can't locate object method "new" via package "MarpaX::Languages::C::AST" at t/asm-opaque.t line 13, <DATA> line 1.
# Looks like you planned 2 tests but ran 1.
# Looks like you failed 1 test of 1 run.
# Looks like your test exited with 255 just after 1.
FAILED--Further testing stopped.
```

WBR, basiliscos