### PR TITLE
Fix issue with shared dir

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -106,7 +106,8 @@ meta_noindex = 1        ; respect prior no_index directives
  
 ; build system
 [ExecDir]           ; include 'bin/*' as executables
-[ShareDir]          ; include 'share/' for File::ShareDir
+[ShareDir]          ; include shared resources for File::ShareDir
+dir = share/dist/MarpaX-Languages-C-AST
 [MakeMaker]         ; create Makefile.PL
 [OSPrereqs / MSWin32]
 Win32::ShellQuote => 0


### PR DESCRIPTION
Hi!

You use File::ShareDir::ProjectDistDir strict => 1, so it looks for shared resources at <root>/<projectdir>/dist/<DISTNAME>/. That works fine for development mode, but at installation the same share/<projectdir>/dist/<DISTNAME>/  should be defined, otherwise it looks the shared files in wrong location, 
i.e.

<pre>
perl -I lib bin/cscan --xml /tmp/gl.h
Uncaught exception from user code:
    Cannot find or evaluate "allNodes.xpath". Search path was: ["/home/basiliscos/perl5/perlbrew/perls/perl-5.20.1/lib/site_perl/5.20.1/auto/share/dist/MarpaX-Languages-C-AST/xpath"] at bin/cscan line 146.
    MarpaX::Languages::C::AST::Grammar::ISO_ANSI_C_2011::Scan::_xpath(MarpaX::Languages::C::AST::Grammar::ISO_ANSI_C_2011::Scan=HASH(0x2f8e158), "allNodes.xpath") called at lib/MarpaX/Languages/C/AST/Grammar/ISO_ANSI_C_2011/Scan.pm line 689
    MarpaX::Languages::C::AST::Grammar::ISO_ANSI_C_2011::Scan::_ast(MarpaX::Languages::C::AST::Grammar::ISO_ANSI_C_2011::Scan=HASH(0x2f8e158)) called at lib/MarpaX/Languages/C/AST/Grammar/ISO_ANSI_C_2011/Scan.pm line 215
    MarpaX::Languages::C::AST::Grammar::ISO_ANSI_C_2011::Scan::new("MarpaX::Languages::C::AST::Grammar::ISO_ANSI_C_2011::Scan", "asDOM", 1, "enumType", "int", "filename", "/tmp/gl.h", "filename_filter", qr(gl\.h), ...) called at lib/MarpaX/Languages/C/Scan.pm line 66
    MarpaX::Languages::C::Scan::new("MarpaX::Languages::C::Scan", "filename", "/tmp/gl.h", "enumType", "int", "asDOM", 1, "filename_filter", qr(gl\.h), ...) called at bin/cscan line 146
</pre>


So, it looks at *\* /home/basiliscos/perl5/perlbrew/perls/perl-5.20.1/lib/site_perl/5.20.1/auto/share/dist/MarpaX-Languages-C-AST/xpath *_, while the resources are actually located at *_ /home/basiliscos/perl5/perlbrew/perls/perl-5.20.1/lib/site_perl/5.20.1/auto/share/dist/MarpaX-Languages-C-AST/dist/MarpaX-Languages-C-AST/xpath/ **. 

The proposed patch fixes that.
